### PR TITLE
V7.0

### DIFF
--- a/Toolset-llvm-vs2017-x64.props
+++ b/Toolset-llvm-vs2017-x64.props
@@ -32,7 +32,8 @@
   <Import Project="$(_PlatformFolder)Platform.Common.props" />
 
   <PropertyGroup>
-    <LLVMInstallDir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
+    <LLVMInstallDir>$(LLVM_ROOT)</LLVMInstallDir>
+    <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
     <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\LLVM\LLVM)</LLVMInstallDir>
     <ExecutablePath>$(LLVMInstallDir)\bin;$(ExecutablePath)</ExecutablePath>
 	<IncludePath>$(LLVMInstallDir)\lib\clang\7.0.0\include;$(IncludePath)</IncludePath>	<LibraryPath>$(LLVMInstallDir)\lib\clang\7.0.0\lib\windows;$(LibraryPath)</LibraryPath>

--- a/Toolset-llvm-vs2017-x86.props
+++ b/Toolset-llvm-vs2017-x86.props
@@ -32,7 +32,8 @@
   <Import Project="$(_PlatformFolder)Platform.Common.props" />
 
   <PropertyGroup>
-    <LLVMInstallDir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
+    <LLVMInstallDir>$(LLVM_ROOT)</LLVMInstallDir>
+    <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
     <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\LLVM\LLVM)</LLVMInstallDir>
     <ExecutablePath>$(LLVMInstallDir)\bin;$(ExecutablePath)</ExecutablePath>
 	<IncludePath>$(LLVMInstallDir)\lib\clang\7.0.0\include;$(IncludePath)</IncludePath>

--- a/Toolset-llvm-vs2017-xp-x64.props
+++ b/Toolset-llvm-vs2017-xp-x64.props
@@ -52,7 +52,8 @@
   <Import Project="$(_PlatformFolder)Platform.Common.props" />
   
   <PropertyGroup>
-    <LLVMInstallDir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
+    <LLVMInstallDir>$(LLVM_ROOT)</LLVMInstallDir>
+    <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
     <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\LLVM\LLVM)</LLVMInstallDir>
     <ExecutablePath>$(LLVMInstallDir)\bin;$(ExecutablePath)</ExecutablePath>
 	<IncludePath>$(LLVMInstallDir)\lib\clang\7.0.0\include;$(IncludePath)</IncludePath>

--- a/Toolset-llvm-vs2017-xp-x86.props
+++ b/Toolset-llvm-vs2017-xp-x86.props
@@ -52,7 +52,8 @@
   <Import Project="$(_PlatformFolder)Platform.Common.props" />
   
   <PropertyGroup>
-    <LLVMInstallDir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
+    <LLVMInstallDir>$(LLVM_ROOT)</LLVMInstallDir>
+    <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\LLVM)</LLVMInstallDir>
     <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\LLVM\LLVM)</LLVMInstallDir>
     <ExecutablePath>$(LLVMInstallDir)\bin;$(ExecutablePath)</ExecutablePath>
 	<IncludePath>$(LLVMInstallDir)\lib\clang\7.0.0\include;$(IncludePath)</IncludePath>


### PR DESCRIPTION
This change allows specifying the path to LLVM through the environment variable `%LLVM_ROOT%`.

This is useful for when LLVM was installed not using the installer, or when there's a need to override the installed LLVM location.

Based on [this comment from Stack Overflow](https://stackoverflow.com/questions/38171878/how-do-i-tell-cmake-to-use-clang-on-windows#comment70405429_38174328)